### PR TITLE
Change to official podman version

### DIFF
--- a/.bashrc_dev
+++ b/.bashrc_dev
@@ -1,5 +1,10 @@
 # ~/.bashrc_dev: run commands for all shells in the devcontainer
 
+# podman is only used as a client in the devcontainer unfortunately the
+# ubuntu 20.04 version (3.4.4) requires that you use -r to do this. From
+# 4.2.0 onwards this is not required when CONTAINER_HOST is set.
+alias podman="podman -r"
+
 # devcontainer HOME is /root but USER is passed in and /home/${USER} is mounted
 rc=/home/${USER}/.bashrc_dev
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,9 +14,11 @@ RUN DEBIAN_FRONTEND=noninteractive \
     ca-certificates \
     curl \
     git \
+    gnupg \
     graphviz \
     net-tools \
     openssh-client \
+    podman \
     python3-dev \
     python3-pyqt5 \
     python3-venv \
@@ -26,18 +28,10 @@ RUN DEBIAN_FRONTEND=noninteractive \
 
 
 ########## add podman and docker "outside" #####################################
-
-# podman 4.2 has much better remote support than Ubuntu's apt repos version
-RUN wget http://ftp.us.debian.org/debian/pool/main/libp/libpod/podman_4.2.0+ds1-3_amd64.deb && \
-    apt install -y ./podman* && \
-    rm podman*
-
 # Point podman at the host ("outside") podman's user socket
 # This requires starting a user podman service plus some podman arguments i.e.:
-#   systemctl start podman.socket
-#   podman run -it -e CONTAINER_HOST=unix:/var/run/docker.sock  \
-#         -v=${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/docker.sock  \
-#         --security-opt=label=type:container_runtime_t dev_ws:latest
+#   systemctl start --user podman.socket
+#   podman run -it -e CONTAINER_HOST=unix:/var/run/docker.sock -v=${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/docker.sock --security-opt=label=type:container_runtime_t dev_ws:latest
 # Works for docker clients too, as the socket inside is the default docker one.
 ENV CONTAINER_HOST="unix:/var/run/docker.sock"
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,7 @@
         "peakchen90.open-html-in-browser"
     ],
     // run anything outside the container before startup
-    // "initializeCommand": "systemctl --user start podman.socket",
+    "initializeCommand": "systemctl --user start podman.socket",
     "runArgs": [
         "--security-opt=label=type:container_runtime_t",
         "--annotation=run.oci.keep_original_groups=1",

--- a/dev-u22.code-workspace
+++ b/dev-u22.code-workspace
@@ -3,6 +3,32 @@
         {
             "name": "u22",
             "path": "."
+        },
+        {
+            "name": "dev-c7",
+            "path": "../dev-c7"
+        },
+        {
+            "name": "bl45p",
+            "path": "../bl45p"
+        },
+        {
+            "name": "python3-pip-skeleton",
+            "path": "../python3-pip-skeleton"
+        },
+        {
+            "name": "python3-pip-skeleton-cli",
+            "path": "../python3-pip-skeleton-cli"
+        },
+        {
+            "name": "pmac",
+            "path": "../pmac"
+        },
+        {
+            "path": "../mciwb"
+        },
+        {
+            "path": "../ibek"
         }
     ],
     "settings": {


### PR DESCRIPTION
Use the version of podman in the ubuntu registry.

This requires a '-r' on all invocations to talk to the host podman - use an alias to ensure this is done for the user.